### PR TITLE
Add admin dashboard to manage user accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,8 @@ The app integrates with Stripe for recurring subscriptions. Set `STRIPE_SECRET_K
 subscription and manage billing through the Stripe customer portal. Webhook events update the
 `billing_subscriptions` table.
 
+## Admin Dashboard
+Users marked as admins can access `admin_dashboard.php` from their account page. The dashboard
+lists all registered users along with their latest subscription status and allows administrators
+to delete accounts.
+

--- a/account.php
+++ b/account.php
@@ -20,6 +20,9 @@ $sub = $stmt->fetch();
 <div class="max-w-xl mx-auto bg-white p-6 rounded shadow">
 <h2 class="text-xl mb-4">Account</h2>
 <p><a class="text-blue-600" href="logout.php">Logout</a></p>
+<?php if (current_user_is_admin()): ?>
+<p class="mt-2"><a class="text-blue-600" href="admin_dashboard.php">Admin Dashboard</a></p>
+<?php endif; ?>
 <?php if ($sub): ?>
 <p class="mt-4">Subscription status: <strong><?= htmlspecialchars($sub['status']) ?></strong></p>
 <?php if ($sub['status'] === 'active'): ?>

--- a/admin_dashboard.php
+++ b/admin_dashboard.php
@@ -1,0 +1,66 @@
+<?php
+require 'config.php';
+require 'auth.php';
+require_admin();
+
+// Fetch all users
+$stmt = $pdo->query('SELECT id, email, name, created_at, is_admin FROM users ORDER BY created_at DESC');
+$users = $stmt->fetchAll();
+
+// Fetch subscription status for each user
+$subs = [];
+if ($users) {
+    $ids = array_column($users, 'id');
+    $in  = str_repeat('?,', count($ids) - 1) . '?';
+    $subStmt = $pdo->prepare("SELECT user_id, status FROM billing_subscriptions WHERE id IN (SELECT MAX(id) FROM billing_subscriptions WHERE user_id IN ($in) GROUP BY user_id)");
+    $subStmt->execute($ids);
+    foreach ($subStmt->fetchAll() as $row) {
+        $subs[$row['user_id']] = $row['status'];
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Admin Dashboard</title>
+<script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 p-8">
+<div class="max-w-4xl mx-auto bg-white p-6 rounded shadow">
+<h2 class="text-2xl mb-4">Admin Dashboard</h2>
+<p class="mb-4"><a class="text-blue-600" href="account.php">Back to account</a></p>
+<table class="min-w-full bg-white border">
+<thead>
+<tr>
+<th class="border px-2 py-1 text-left">ID</th>
+<th class="border px-2 py-1 text-left">Email</th>
+<th class="border px-2 py-1 text-left">Name</th>
+<th class="border px-2 py-1 text-left">Admin</th>
+<th class="border px-2 py-1 text-left">Registered</th>
+<th class="border px-2 py-1 text-left">Subscription</th>
+<th class="border px-2 py-1 text-left">Actions</th>
+</tr>
+</thead>
+<tbody>
+<?php foreach ($users as $u): ?>
+<tr>
+<td class="border px-2 py-1"><?php echo $u['id']; ?></td>
+<td class="border px-2 py-1"><?php echo htmlspecialchars($u['email']); ?></td>
+<td class="border px-2 py-1"><?php echo htmlspecialchars($u['name']); ?></td>
+<td class="border px-2 py-1 text-center"><?php echo $u['is_admin'] ? 'yes' : 'no'; ?></td>
+<td class="border px-2 py-1"><?php echo $u['created_at']; ?></td>
+<td class="border px-2 py-1"><?php echo htmlspecialchars($subs[$u['id']] ?? 'none'); ?></td>
+<td class="border px-2 py-1">
+<form method="post" action="admin_delete_user.php" onsubmit="return confirm('Delete this user?');">
+<input type="hidden" name="user_id" value="<?php echo $u['id']; ?>">
+<button class="bg-red-600 text-white px-2 py-1 rounded" type="submit">Delete</button>
+</form>
+</td>
+</tr>
+<?php endforeach; ?>
+</tbody>
+</table>
+</div>
+</body>
+</html>

--- a/admin_delete_user.php
+++ b/admin_delete_user.php
@@ -1,0 +1,16 @@
+<?php
+require 'config.php';
+require 'auth.php';
+require_admin();
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['user_id'])) {
+    $id = (int)$_POST['user_id'];
+    $stmt = $pdo->prepare('DELETE FROM users WHERE id = ?');
+    $stmt->execute([$id]);
+    // Optionally delete subscriptions
+    $stmt = $pdo->prepare('DELETE FROM billing_subscriptions WHERE user_id = ?');
+    $stmt->execute([$id]);
+}
+header('Location: admin_dashboard.php');
+exit;
+?>

--- a/auth.php
+++ b/auth.php
@@ -11,4 +11,17 @@ function require_login() {
 function current_user_id() {
     return $_SESSION['user_id'] ?? null;
 }
+
+function current_user_is_admin() {
+    return !empty($_SESSION['is_admin']);
+}
+
+function require_admin() {
+    require_login();
+    if (!current_user_is_admin()) {
+        http_response_code(403);
+        echo 'Access denied';
+        exit;
+    }
+}
 ?>

--- a/login.php
+++ b/login.php
@@ -5,11 +5,12 @@ require 'auth.php';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $email = trim($_POST['email'] ?? '');
     $password = $_POST['password'] ?? '';
-    $stmt = $pdo->prepare('SELECT id, password_hash FROM users WHERE email = ?');
+    $stmt = $pdo->prepare('SELECT id, password_hash, is_admin FROM users WHERE email = ?');
     $stmt->execute([$email]);
     $user = $stmt->fetch();
     if ($user && password_verify($password, $user['password_hash'])) {
         $_SESSION['user_id'] = $user['id'];
+        $_SESSION['is_admin'] = $user['is_admin'];
         header('Location: account.php');
         exit;
     } else {

--- a/schema.sql
+++ b/schema.sql
@@ -61,6 +61,7 @@ CREATE TABLE IF NOT EXISTS users (
     email VARCHAR(255) NOT NULL UNIQUE,
     password_hash VARCHAR(255) NOT NULL,
     name VARCHAR(255),
+    is_admin TINYINT(1) DEFAULT 0,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 


### PR DESCRIPTION
## Summary
- add `is_admin` field to users table
- expose admin session data in login flow
- add helpers for admin permission checks
- link to admin dashboard from account page
- implement `admin_dashboard.php` for user management
- allow admins to remove users
- document admin dashboard in README

## Testing
- `php -l login.php`
- `php -l auth.php`
- `php -l account.php`
- `php -l admin_dashboard.php`
- `php -l admin_delete_user.php`


------
https://chatgpt.com/codex/tasks/task_e_68527649c78c83268ebf837e9f1e9d05