### PR TITLE
Implement retry support for OpenAI requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,4 +21,5 @@ STRIPE_PRICE_ID=your_price_id
 WHM_HOST=https://whm.example.com:2087
 WHM_API_TOKEN=your_whm_api_token
 WHM_ROOT_USER=root
+OPENAI_RETRY_LIMIT=3
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ This repository contains a simple PHP prototype based on the PRD. The app lets u
 ## Setup
 1. Create a MySQL database and user. Import `schema.sql`.
 2. Copy `.env.example` to `.env` and set your DB credentials along with an `OPENAI_API_KEY`.
-   The `config.php` loader will export each variable so it can also be read
-   with `getenv()`.
+   You can optionally set `OPENAI_RETRY_LIMIT` to control how many times API
+   requests are retried when a failure occurs (defaults to 3). The `config.php`
+   loader will export each variable so it can also be read with `getenv()`.
 3. Serve the PHP files with Apache or PHP's built-in server:
    ```bash
    php -S localhost:8000


### PR DESCRIPTION
## Summary
- add `openaiChatRequest` helper with retry logic
- update OpenAI helper functions to use the retry-enabled helper
- document `OPENAI_RETRY_LIMIT` environment variable
- include variable in example environment file

## Testing
- `php -l openai_helper.php`
- `php -l upload.php`
- `ls *.php | xargs -I{} php -l {}`


------
https://chatgpt.com/codex/tasks/task_e_68809841e6e8832689bade193a4dc789