### PR TITLE
Improve OpenAI parsing on preview page

### DIFF
--- a/openai_helper.php
+++ b/openai_helper.php
@@ -81,7 +81,17 @@ function sendImageToOpenAI(string $imagePath, ?string &$error = null) {
         ]]
     ];
 
-    return openaiChatRequest($postData, $error);
+    $response = openaiChatRequest($postData, $error);
+    if (!$response) {
+        return null;
+    }
+
+    $json = json_decode($response, true);
+    if (!$json || !isset($json['choices'][0]['message']['content'])) {
+        return null;
+    }
+
+    return trim($json['choices'][0]['message']['content']);
 }
 /**
  * Convert PDF to image using Imagick


### PR DESCRIPTION
## Summary
- update `sendImageToOpenAI` to return message text instead of the full API JSON
- parse Markdown bullet lists in `preview.php` so key/value pairs become form fields

## Testing
- `php -l openai_helper.php`
- `php -l preview.php`
- `php -l upload.php`


------
https://chatgpt.com/codex/tasks/task_e_68812b2d25848326950d58e99b95923a