### PR TITLE
Improve bullet list parsing

### DIFF
--- a/preview.php
+++ b/preview.php
@@ -37,16 +37,30 @@ if (!$upload) {
 }
 
 function parseBulletList(string $text): array {
-    $lines = preg_split('/\r?\n/', $text);
     $data = [];
-    foreach ($lines as $line) {
-        $line = trim($line, "- \t");
-        if (preg_match('/\*\*(.+?)\*\*:\s*(.+)/', $line, $m) || preg_match('/^(.+?):\s*(.+)/', $line, $m)) {
+
+    // Capture patterns like **Key**: Value anywhere in the text
+    if (preg_match_all('/\*\*\s*(.+?)\s*\*\*\s*:\s*([^\n]+)/', $text, $matches, PREG_SET_ORDER)) {
+        foreach ($matches as $m) {
             $key = strtolower(str_replace(' ', '_', trim($m[1])));
             $value = trim($m[2]);
             $data[$key] = $value;
         }
     }
+
+    // Fallback/extra parsing for lines with "Key: Value" or "Key - Value"
+    $lines = preg_split('/\r?\n/', $text);
+    foreach ($lines as $line) {
+        $line = trim($line, "- \t");
+        if (preg_match('/^([^:]+?):\s*(.+)/', $line, $m) || preg_match('/^(.+?)\s+-\s+(.+)/', $line, $m)) {
+            $key = strtolower(str_replace(' ', '_', trim($m[1])));
+            $value = trim($m[2]);
+            if (!isset($data[$key])) {
+                $data[$key] = $value;
+            }
+        }
+    }
+
     return $data;
 }
 


### PR DESCRIPTION
## Summary
- make parsing of OpenAI text more robust
- handle **Key**: Value anywhere in the output
- parse additional patterns like "Key - Value"

## Testing
- `php -l preview.php`


------
https://chatgpt.com/codex/tasks/task_e_68813c88f7c08326a831a3d771a9e2be