### PR TITLE
Fix preview form to exclude raw text fields

### DIFF
--- a/preview.php
+++ b/preview.php
@@ -18,6 +18,8 @@ if ($upload) {
             if (isset($data['business_info']) || isset($data['design_elements'])) {
                 $analysisJson = json_encode($data, JSON_PRETTY_PRINT);
                 $analysisArray = $data;
+                // Exclude raw text fields from the editable form
+                unset($analysisArray['openai_text'], $analysisArray['raw_text']);
             } elseif (!empty($data['openai_text'])) {
                 $analysisJson = $data['openai_text'];
                 // Attempt to parse markdown bullet list into key/value pairs


### PR DESCRIPTION
## Summary
- hide `openai_text` and `raw_text` when rendering editable business card data

## Testing
- `php -l preview.php`

------
https://chatgpt.com/codex/tasks/task_e_688155828f288326aa7f3edc89940e1a