### PR TITLE
Add payment step for domain registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ Set `WHM_HOST`, `WHM_API_TOKEN`, and `WHM_ROOT_USER` in your `.env` file for dep
 Use `publish_to_whm.php?upload_id=ID&domain=example.com` to create a new WHM account and upload the generated site to the account's `public_html` directory.
 
 ## Billing
-The app integrates with Stripe for recurring subscriptions. Set `STRIPE_SECRET_KEY` and
-`STRIPE_PRICE_ID` in your `.env` file. After registering and logging in, users can start a
-subscription and manage billing through the Stripe customer portal. Webhook events update the
-`billing_subscriptions` table.
+The app integrates with Stripe for recurring subscriptions. Set `STRIPE_SECRET_KEY`,
+`STRIPE_PRICE_ID_MONTHLY`, and `STRIPE_PRICE_ID_YEARLY` in your `.env` file. After registering and
+logging in, users can start a subscription and manage billing through the Stripe customer portal.
+Webhook events update the `billing_subscriptions` table.
 
 ## Admin Dashboard
 Users marked as admins can access `admin_dashboard.php` from their account page. The dashboard

--- a/domain_search.php
+++ b/domain_search.php
@@ -62,7 +62,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     </td>
                     <td class="p-2 text-center">
                         <?php if ($avail): ?>
-                        <a href="register_domain.php?domain=<?= urlencode($dom) ?>&upload_id=<?= $id ?>" class="bg-green-600 text-white px-2 py-1 rounded">Register</a>
+                        <a href="payment.php?domain=<?= urlencode($dom) ?>&upload_id=<?= $id ?>" class="bg-green-600 text-white px-2 py-1 rounded">Register</a>
                         <?php endif; ?>
                     </td>
                 </tr>
@@ -80,7 +80,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     <?php if ($customAvail === null): ?>Unknown<?php elseif ($customAvail): ?>Available<?php else: ?>Taken<?php endif; ?>
                 </p>
                 <?php if ($customAvail): ?>
-                <a href="register_domain.php?domain=<?= urlencode($customDomain) ?>&upload_id=<?= $id ?>" class="bg-green-600 text-white px-2 py-1 rounded inline-block mt-2">Register</a>
+                <a href="payment.php?domain=<?= urlencode($customDomain) ?>&upload_id=<?= $id ?>" class="bg-green-600 text-white px-2 py-1 rounded inline-block mt-2">Register</a>
                 <?php endif; ?>
             </div>
             <?php endif; ?>

--- a/payment.php
+++ b/payment.php
@@ -1,0 +1,29 @@
+<?php
+require 'auth.php';
+require_login();
+
+$domain = $_GET['domain'] ?? '';
+$uploadId = isset($_GET['upload_id']) ? (int)$_GET['upload_id'] : 0;
+if ($domain === '') {
+    die('Domain not specified');
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Choose Plan</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100">
+    <div class="container mx-auto p-8 text-center">
+        <h1 class="text-2xl font-bold mb-4">Register <?= htmlspecialchars($domain) ?></h1>
+        <p class="mb-6">Select a hosting plan to continue to checkout.</p>
+        <div class="flex justify-center space-x-4">
+            <a href="subscribe.php?plan=monthly&domain=<?= urlencode($domain) ?>&upload_id=<?= $uploadId ?>" class="bg-blue-600 text-white px-4 py-2 rounded">$24.99 / Month</a>
+            <a href="subscribe.php?plan=yearly&domain=<?= urlencode($domain) ?>&upload_id=<?= $uploadId ?>" class="bg-green-600 text-white px-4 py-2 rounded">$199 / Year</a>
+        </div>
+    </div>
+</body>
+</html>

--- a/stripe_helper.php
+++ b/stripe_helper.php
@@ -29,11 +29,12 @@ function stripeRequest(string $method, string $endpoint, array $params = []) {
 }
 
 function createCheckoutSession(string $customerEmail, string $priceId, string $successUrl, string $cancelUrl) {
+    $separator = (strpos($successUrl, '?') === false) ? '?' : '&';
     $params = [
         'mode' => 'subscription',
         'customer_email' => $customerEmail,
         'line_items' => [[ 'price' => $priceId, 'quantity' => 1 ]],
-        'success_url' => $successUrl . '?session_id={CHECKOUT_SESSION_ID}',
+        'success_url' => $successUrl . $separator . 'session_id={CHECKOUT_SESSION_ID}',
         'cancel_url' => $cancelUrl
     ];
     // Because Stripe expects line_items[] style fields, manually build query

--- a/subscribe.php
+++ b/subscribe.php
@@ -13,9 +13,17 @@ if (!$user) {
     die('User not found');
 }
 
-$priceId = getenv('STRIPE_PRICE_ID');
-$successUrl = (isset($_SERVER['HTTPS']) ? 'https://' : 'http://') . $_SERVER['HTTP_HOST'] . '/subscribe_success.php';
-$cancelUrl = (isset($_SERVER['HTTPS']) ? 'https://' : 'http://') . $_SERVER['HTTP_HOST'] . '/account.php';
+$domain = $_GET['domain'] ?? '';
+$uploadId = isset($_GET['upload_id']) ? (int)$_GET['upload_id'] : 0;
+$plan = $_GET['plan'] ?? 'monthly';
+if (!in_array($plan, ['monthly', 'yearly'])) {
+    $plan = 'monthly';
+}
+
+$priceId = getenv($plan === 'yearly' ? 'STRIPE_PRICE_ID_YEARLY' : 'STRIPE_PRICE_ID_MONTHLY');
+$baseUrl = (isset($_SERVER['HTTPS']) ? 'https://' : 'http://') . $_SERVER['HTTP_HOST'];
+$successUrl = $baseUrl . '/subscribe_success.php?domain=' . urlencode($domain) . '&upload_id=' . $uploadId;
+$cancelUrl = $baseUrl . '/payment.php?domain=' . urlencode($domain) . '&upload_id=' . $uploadId;
 $session = createCheckoutSession($user['email'], $priceId, $successUrl, $cancelUrl);
 if ($session && isset($session['url'])) {
     header('Location: ' . $session['url']);

--- a/subscribe_success.php
+++ b/subscribe_success.php
@@ -6,6 +6,8 @@ require_login();
 
 $userId = current_user_id();
 $sessionId = $_GET['session_id'] ?? null;
+$domain = $_GET['domain'] ?? '';
+$uploadId = isset($_GET['upload_id']) ? (int)$_GET['upload_id'] : 0;
 if ($sessionId) {
     $session = stripeRequest('GET', 'checkout/sessions/' . $sessionId);
     if ($session && isset($session['subscription'], $session['customer'])) {
@@ -13,6 +15,10 @@ if ($sessionId) {
         $stmt->execute([$userId, $session['customer'], $session['subscription'], 'hosting', 'active']);
     }
 }
-header('Location: account.php');
+if ($domain !== '' && $uploadId > 0) {
+    header('Location: register_domain.php?domain=' . urlencode($domain) . '&upload_id=' . $uploadId);
+} else {
+    header('Location: account.php');
+}
 exit;
 ?>


### PR DESCRIPTION
## Summary
- route domain registration through a payment gate
- introduce plan selection and pass domain info through checkout
- support success URLs with query parameters

## Testing
- `php -l domain_search.php payment.php subscribe.php subscribe_success.php stripe_helper.php`

------
https://chatgpt.com/codex/tasks/task_e_68919598847c8326be22d3e5ac52695f