### PR TITLE
Merge registration and payment step

### DIFF
--- a/check_email.php
+++ b/check_email.php
@@ -1,0 +1,14 @@
+<?php
+require 'config.php';
+
+header('Content-Type: application/json');
+$email = trim($_GET['email'] ?? '');
+$exists = false;
+if ($email !== '') {
+    $stmt = $pdo->prepare('SELECT 1 FROM users WHERE email = ?');
+    $stmt->execute([$email]);
+    $exists = $stmt->fetchColumn() ? true : false;
+}
+echo json_encode(['exists' => $exists]);
+?>
+

--- a/login.php
+++ b/login.php
@@ -2,16 +2,18 @@
 require 'config.php';
 require 'auth.php';
 
+$next = $_GET['next'] ?? 'account.php';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $email = trim($_POST['email'] ?? '');
     $password = $_POST['password'] ?? '';
+    $next = $_POST['next'] ?? $next;
     $stmt = $pdo->prepare('SELECT id, password_hash, is_admin FROM users WHERE email = ?');
     $stmt->execute([$email]);
     $user = $stmt->fetch();
     if ($user && password_verify($password, $user['password_hash'])) {
         $_SESSION['user_id'] = $user['id'];
         $_SESSION['is_admin'] = $user['is_admin'];
-        header('Location: account.php');
+        header('Location: ' . $next);
         exit;
     } else {
         $error = 'Invalid credentials';
@@ -32,6 +34,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <form method="post">
 <input class="border p-2 w-full mb-2" type="email" name="email" placeholder="Email" required />
 <input class="border p-2 w-full mb-4" type="password" name="password" placeholder="Password" required />
+<input type="hidden" name="next" value="<?= htmlspecialchars($next) ?>" />
 <button class="bg-blue-600 text-white px-4 py-2 rounded" type="submit">Login</button>
 </form>
 <p class="mt-2">No account? <a class="text-blue-600" href="register.php">Register</a></p>

--- a/payment.php
+++ b/payment.php
@@ -1,11 +1,37 @@
 <?php
+require 'config.php';
 require 'auth.php';
-require_login();
 
 $domain = $_GET['domain'] ?? '';
 $uploadId = isset($_GET['upload_id']) ? (int)$_GET['upload_id'] : 0;
 if ($domain === '') {
     die('Domain not specified');
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $email = trim($_POST['email'] ?? '');
+    $password = $_POST['password'] ?? '';
+    $plan = $_POST['plan'] ?? 'monthly';
+    if (!in_array($plan, ['monthly', 'yearly'])) {
+        $plan = 'monthly';
+    }
+    if ($email && $password) {
+        $stmt = $pdo->prepare('SELECT id FROM users WHERE email = ?');
+        $stmt->execute([$email]);
+        if ($stmt->fetch()) {
+            $error = 'Email already registered. Please login.';
+        } else {
+            $hash = password_hash($password, PASSWORD_DEFAULT);
+            $insert = $pdo->prepare('INSERT INTO users (email, password_hash) VALUES (?, ?)');
+            $insert->execute([$email, $hash]);
+            $_SESSION['user_id'] = $pdo->lastInsertId();
+            $_SESSION['is_admin'] = 0;
+            header('Location: subscribe.php?plan=' . urlencode($plan) . '&domain=' . urlencode($domain) . '&upload_id=' . $uploadId);
+            exit;
+        }
+    } else {
+        $error = 'Email and password required';
+    }
 }
 ?>
 <!DOCTYPE html>
@@ -17,13 +43,40 @@ if ($domain === '') {
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-gray-100">
-    <div class="container mx-auto p-8 text-center">
-        <h1 class="text-2xl font-bold mb-4">Register <?= htmlspecialchars($domain) ?></h1>
-        <p class="mb-6">Select a hosting plan to continue to checkout.</p>
-        <div class="flex justify-center space-x-4">
-            <a href="subscribe.php?plan=monthly&domain=<?= urlencode($domain) ?>&upload_id=<?= $uploadId ?>" class="bg-blue-600 text-white px-4 py-2 rounded">$24.99 / Month</a>
-            <a href="subscribe.php?plan=yearly&domain=<?= urlencode($domain) ?>&upload_id=<?= $uploadId ?>" class="bg-green-600 text-white px-4 py-2 rounded">$199 / Year</a>
+    <div class="container mx-auto p-8 max-w-md">
+        <h1 class="text-2xl font-bold mb-4 text-center">Register <?= htmlspecialchars($domain) ?></h1>
+        <?php if (!empty($error)) echo '<p class="text-red-600 mb-4">' . htmlspecialchars($error) . '</p>'; ?>
+        <form method="post" class="bg-white p-6 rounded shadow">
+            <input id="email" class="border p-2 w-full mb-2" type="email" name="email" placeholder="Email" required />
+            <p id="email-msg"></p>
+            <input class="border p-2 w-full mb-4" type="password" name="password" placeholder="Password" required />
+            <div class="mb-4">
+                <label class="mr-4"><input type="radio" name="plan" value="monthly" checked /> $24.99 / Month</label>
+                <label><input type="radio" name="plan" value="yearly" /> $199 / Year</label>
+            </div>
+            <button class="bg-blue-600 text-white px-4 py-2 rounded w-full" type="submit">Checkout</button>
+        </form>
+        <?php $next = urlencode('payment.php?domain=' . $domain . '&upload_id=' . $uploadId); ?>
+        <div class="text-center mt-4">
+            <a href="login.php?next=<?= $next ?>" class="text-blue-600">Returning User? Login</a>
         </div>
     </div>
+    <script>
+    document.getElementById('email').addEventListener('blur', function() {
+        fetch('check_email.php?email=' + encodeURIComponent(this.value))
+            .then(r => r.json())
+            .then(data => {
+                const msg = document.getElementById('email-msg');
+                if (data.exists) {
+                    msg.textContent = 'Email already registered. Please use Returning User to login.';
+                    msg.className = 'text-red-600 mb-2';
+                } else {
+                    msg.textContent = '';
+                    msg.className = '';
+                }
+            });
+    });
+    </script>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- Combine signup and plan selection into a single payment form.
- Added email availability check endpoint and client-side validation.
- Support redirecting returning users back to payment after login.

## Testing
- `php -l payment.php`
- `php -l check_email.php`
- `php -l login.php`


------
https://chatgpt.com/codex/tasks/task_e_68919b057f008326a5c7b6e2d119501e