### PR TITLE
Fix billing portal session creation with STRIPE_SECRET_KEY constant fallback

### DIFF
--- a/stripe_helper.php
+++ b/stripe_helper.php
@@ -1,6 +1,10 @@
 <?php
 function stripeRequest(string $method, string $endpoint, array $params = []) {
     $secret = getenv('STRIPE_SECRET_KEY');
+    // Fallback to defined constant if environment variable is not set
+    if (!$secret && defined('STRIPE_SECRET_KEY')) {
+        $secret = STRIPE_SECRET_KEY;
+    }
     if (!$secret) {
         return null;
     }


### PR DESCRIPTION
## Summary
- ensure Stripe secret key is read from defined constant when environment variable is unavailable

## Testing
- `php -l stripe_helper.php`
- `php -l portal.php`


------
https://chatgpt.com/codex/tasks/task_e_6893abba4de483268181c94fa61da9dc