### PR TITLE
Handle WHM account creation success correctly

### DIFF
--- a/publish_to_whm.php
+++ b/publish_to_whm.php
@@ -12,10 +12,12 @@ if ($domain === '' || $uploadId === 0) {
 $username = substr(preg_replace('/[^a-z0-9]/i', '', explode('.', $domain)[0]), 0, 8);
 $password = bin2hex(random_bytes(8));
 
-$create = createWhmAccount($username, $domain, $password);
-$created = $create && ($create['metadata']['result'] ?? 0) == 1;
+$create  = createWhmAccount($username, $domain, $password);
+$created = $create['ok'] && (($create['data']['metadata']['result'] ?? 0) == 1);
 
-error_log(__LINE__." - ".print_r($created, TRUE));
+if (!$created) {
+    error_log('WHM account creation failed: ' . ($create['error'] ?? 'unknown error'));
+}
 
 $uploadSuccess = false;
 if ($created) {


### PR DESCRIPTION
## Summary
- Detect WHM account creation success using the new `whmApiRequest` response format
- Log WHM account errors for easier troubleshooting

## Testing
- `php -l publish_to_whm.php`
- `php -l whm_helper.php`


------
https://chatgpt.com/codex/tasks/task_e_68aac600bdac83268d484e1e42c210b6