### PR TITLE
Improve FTP upload reliability

### DIFF
--- a/whm_token_test.php
+++ b/whm_token_test.php
@@ -78,54 +78,82 @@ function uploadToCpanel(
     string $cpanelUser,
     string $cpanelPass,
     string $filePath,
-    string $remoteFile = 'public_html/index.html'
+    string $remoteFile = 'public_html/index.html',
+    string $address = ''
 ): bool {
-    $hostUrl = normalizeWhmHost(getenv('WHM_HOST'));
+    $hostUrl = $address ?: normalizeWhmHost(getenv('WHM_HOST'));
     $host    = $hostUrl ? parse_url($hostUrl, PHP_URL_HOST) : null;
     if (!$host || !is_file($filePath)) {
+        error_log('Invalid host or local file missing.');
         return false;
     }
 
-    $conn = @ftp_ssl_connect($host);
+    $conn = ftp_ssl_connect($host);
     if (!$conn) {
-        $conn = @ftp_connect($host);
+        $conn = ftp_connect($host);
     }
     if (!$conn) {
+        error_log("Could not connect to $host");
         return false;
     }
-    if (!@ftp_login($conn, $cpanelUser, $cpanelPass)) {
+
+    $loginOk = false;
+    for ($i = 0; $i < 5 && !$loginOk; $i++) {
+        $loginOk = ftp_login($conn, $cpanelUser, $cpanelPass);
+        if (!$loginOk) {
+            error_log("FTP login attempt $i failed for $cpanelUser");
+            sleep(1);
+        }
+    }
+    if (!$loginOk) {
         ftp_close($conn);
         return false;
     }
     ftp_pasv($conn, true);
 
     $remoteDir = dirname($remoteFile);
-    @ftp_mkdir($conn, $remoteDir);
+    if (!@ftp_chdir($conn, $remoteDir)) {
+        $parts = explode('/', $remoteDir);
+        $path  = '';
+        foreach ($parts as $part) {
+            if ($part === '' || $part === '.') {
+                continue;
+            }
+            $path .= '/' . $part;
+            if (!@ftp_chdir($conn, $path)) {
+                if (!ftp_mkdir($conn, $path)) {
+                    error_log('Could not create remote directory: ' . $path);
+                }
+            }
+        }
+    }
 
-    $html = @file_get_contents($filePath);
+    $html = file_get_contents($filePath);
     if ($html === false) {
         ftp_close($conn);
         return false;
     }
-
     $html = preg_replace('#https?://[^/]+/generated_images/#', 'generated_images/', $html);
 
     $tmp = tempnam(sys_get_temp_dir(), 'cphtml');
     file_put_contents($tmp, $html);
-    $uploadOk = @ftp_put($conn, $remoteFile, $tmp, FTP_ASCII);
+    $uploadOk = ftp_put($conn, $remoteFile, $tmp, FTP_BINARY);
     unlink($tmp);
     if (!$uploadOk) {
+        error_log('Upload failed for ' . $remoteFile);
         ftp_close($conn);
         return false;
     }
 
-    if (preg_match_all('/generated_images\/([^"\'"\s>]+)/i', $html, $m)) {
+    if (preg_match_all('/generated_images\/([^"\'\s>]+)/i', $html, $m)) {
         $imgRemoteDir = $remoteDir . '/generated_images';
         @ftp_mkdir($conn, $imgRemoteDir);
         foreach (array_unique($m[1]) as $img) {
             $localImg = __DIR__ . '/generated_images/' . basename($img);
             if (is_file($localImg)) {
-                @ftp_put($conn, $imgRemoteDir . '/' . basename($img), $localImg, FTP_BINARY);
+                if (!ftp_put($conn, $imgRemoteDir . '/' . basename($img), $localImg, FTP_BINARY)) {
+                    error_log('Failed to upload image ' . $img);
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- Use binary FTP transfers and real error logging
- Ensure remote directories exist before uploads
- Mirror updated upload helper in test script

## Testing
- `php -l whm_helper.php`
- `php -l whm_token_test.php`


------
https://chatgpt.com/codex/tasks/task_e_68ab6abe9058832693de701669ceae0e