### PR TITLE
Append domain to manifest generation request

### DIFF
--- a/publish_to_whm.php
+++ b/publish_to_whm.php
@@ -25,7 +25,7 @@ if (!$created) {
 $manifestSuccess = false;
 if ($created) {
     sleep(2);
-    $manifestSuccess = callManifest($username, $uploadId);
+    $manifestSuccess = callManifest($username, $uploadId, $domain);
 }
 ?>
 <!DOCTYPE html>

--- a/whm_helper.php
+++ b/whm_helper.php
@@ -447,7 +447,7 @@ function uploadToCpanel(
     return true;
 }
 
-function callManifest(string $username, int $id): bool {
+function callManifest(string $username, int $id, string $domain): bool {
     $host = getenv('WHM_HOST');
     if (!$host) {
         error_log('WHM_HOST not set.');
@@ -459,7 +459,13 @@ function callManifest(string $username, int $id): bool {
     $baseHost = $parts['host'] ?? $host;
     $baseUrl = $scheme . '://' . $baseHost;
 
-    $url = sprintf('%s/~%s/manifest.php?id=%d', $baseUrl, rawurlencode($username), $id);
+    $url = sprintf(
+        '%s/~%s/manifest.php?id=%d&domain=%s',
+        $baseUrl,
+        rawurlencode($username),
+        $id,
+        rawurlencode($domain)
+    );
 
     $opts = [
         'http' => [


### PR DESCRIPTION
## Summary
- Pass domain to callManifest and include it in the manifest URL so the remote site receives both the username and domain context
- Update publish_to_whm.php to forward the domain value when calling callManifest

## Testing
- `php -l whm_helper.php`
- `php -l publish_to_whm.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad3764b60c832688c89ec15e10ce0e