### PR TITLE
Store generated image metadata and include in deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This repository contains a simple PHP prototype based on the PRD. The app lets u
 - `uploads/` – uploaded images (ignored in Git)
 - `generated_sites/` – generated HTML output (ignored in Git)
 - `naics_classifications` – table storing NAICS code results
-- `website_images` – table storing additional images uploaded for a site
+- `website_images` – table storing additional images uploaded for a site along with user and URL metadata
 
 Users can review the extracted text on the preview page, make corrections, and generate the site from their edited version. The edits are stored in the new `ocr_edits` table.
 

--- a/generate.php
+++ b/generate.php
@@ -9,6 +9,7 @@ error_log("FILES - ".print_r($_FILES, TRUE));
 require 'config.php';
 require_once 'openai_helper.php';
 require_once 'gemini_helper.php';
+require_once 'auth.php';
 
 $baseUrl = (isset($_SERVER['HTTPS']) ? 'https://' : 'http://') . $_SERVER['HTTP_HOST'];
 
@@ -144,8 +145,13 @@ if (!empty($_FILES['website_images']['name'][0])) {
                 $name = time() . '_' . preg_replace('/[^A-Za-z0-9._-]/', '_', $name);
                 $dest = $imgDir . $name;
                 if (move_uploaded_file($tmp, $dest)) {
-                    $stmt = $pdo->prepare('INSERT INTO website_images (upload_id, filename, created_at) VALUES (?, ?, NOW())');
-                    $stmt->execute([$id, $name]);
+                    $stmt = $pdo->prepare('INSERT INTO website_images (upload_id, user_id, filename, file_url, created_at) VALUES (?, ?, ?, ?, NOW())');
+                    $stmt->execute([
+                        $id,
+                        current_user_id(),
+                        $name,
+                        BASEURL . '/uploads/site_images/' . $id . '/' . $name
+                    ]);
                     $uploadedFiles[] = $name;
                 }
             }

--- a/schema.sql
+++ b/schema.sql
@@ -93,8 +93,11 @@ CREATE TABLE IF NOT EXISTS billing_subscriptions (
 CREATE TABLE IF NOT EXISTS website_images (
     id INT AUTO_INCREMENT PRIMARY KEY,
     upload_id INT NOT NULL,
+    user_id INT DEFAULT NULL,
     filename VARCHAR(255) NOT NULL,
+    file_url VARCHAR(255) NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    FOREIGN KEY (upload_id) REFERENCES uploads(id)
+    FOREIGN KEY (upload_id) REFERENCES uploads(id),
+    FOREIGN KEY (user_id) REFERENCES users(id)
 );
 


### PR DESCRIPTION
## Summary
- track user and URL for uploaded site images
- package generator includes uploaded images with relative paths

## Testing
- `php -l generate.php`
- `php -l publish_to_whm.php`
- `php -l upload_image.php`


------
https://chatgpt.com/codex/tasks/task_e_68b3787f24d08326953bc2d2cab52bcc