### PR TITLE
Support multiple Stripe subscriptions and add recurring report

### DIFF
--- a/account.php
+++ b/account.php
@@ -4,10 +4,9 @@ require 'auth.php';
 require_login();
 
 $userId = current_user_id();
-
-$stmt = $pdo->prepare('SELECT * FROM billing_subscriptions WHERE user_id = ? ORDER BY id DESC LIMIT 1');
+$stmt = $pdo->prepare('SELECT * FROM billing_subscriptions WHERE user_id = ? ORDER BY id DESC');
 $stmt->execute([$userId]);
-$sub = $stmt->fetch();
+$subs = $stmt->fetchAll();
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -16,30 +15,47 @@ $sub = $stmt->fetch();
 <title>Account</title>
 <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-100 p-8">
-<div class="max-w-xl mx-auto bg-white p-6 rounded shadow">
-<h2 class="text-xl mb-4">Account</h2>
-<p><a class="text-blue-600" href="logout.php">Logout</a></p>
-<?php if (current_user_is_admin()): ?>
-<p class="mt-2"><a class="text-blue-600" href="admin_dashboard.php">Admin Dashboard</a></p>
-<?php endif; ?>
-<?php if ($sub): ?>
-<p class="mt-4">Subscription status: <strong><?= htmlspecialchars($sub['status']) ?></strong></p>
-<?php if ($sub['status'] === 'active'): ?>
-<form action="portal.php" method="post" class="mt-4">
-<button class="bg-blue-600 text-white px-4 py-2 rounded" type="submit">Manage Billing</button>
-</form>
-<?php else: ?>
-<form action="subscribe.php" method="post" class="mt-4">
-<button class="bg-blue-600 text-white px-4 py-2 rounded" type="submit">Subscribe</button>
-</form>
-<?php endif; ?>
-<?php else: ?>
-<p>You do not have an active subscription.</p>
-<form action="subscribe.php" method="post" class="mt-4">
-<button class="bg-blue-600 text-white px-4 py-2 rounded" type="submit">Subscribe</button>
-</form>
-<?php endif; ?>
+<body class="bg-gray-100">
+<?php include 'header.php'; ?>
+<div class="max-w-4xl mx-auto p-8">
+    <div class="bg-white p-6 rounded shadow">
+        <h2 class="text-xl mb-4">Account</h2>
+        <p><a class="text-blue-600" href="logout.php">Logout</a></p>
+        <?php if (current_user_is_admin()): ?>
+        <p class="mt-2"><a class="text-blue-600" href="admin_dashboard.php">Admin Dashboard</a></p>
+        <?php endif; ?>
+        <?php if ($subs): ?>
+        <table class="w-full mt-4 text-left">
+            <thead>
+                <tr><th class="p-2">Domain</th><th class="p-2">Status</th><th class="p-2">Actions</th></tr>
+            </thead>
+            <tbody>
+            <?php foreach ($subs as $sub): ?>
+                <tr class="border-t">
+                    <td class="p-2"><?= htmlspecialchars($sub['domain']) ?></td>
+                    <td class="p-2"><?= htmlspecialchars($sub['status']) ?></td>
+                    <td class="p-2">
+                        <form action="portal.php" method="post" class="inline">
+                            <input type="hidden" name="customer_id" value="<?= htmlspecialchars($sub['stripe_customer_id']) ?>" />
+                            <button class="text-blue-600 mr-2" type="submit">Manage Billing</button>
+                        </form>
+                        <?php if (!empty($sub['domain'])): ?>
+                        <a class="text-blue-600 mr-2" href="http://<?= htmlspecialchars($sub['domain']) ?>" target="_blank">Visit</a>
+                        <?php endif; ?>
+                        <a class="text-red-600" href="cancel_subscription.php?id=<?= $sub['id'] ?>">Cancel</a>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+            </tbody>
+        </table>
+        <?php else: ?>
+        <p>You do not have any subscriptions.</p>
+        <form action="subscribe.php" method="post" class="mt-4">
+            <button class="bg-blue-600 text-white px-4 py-2 rounded" type="submit">Subscribe</button>
+        </form>
+        <?php endif; ?>
+    </div>
 </div>
+<?php include 'footer.php'; ?>
 </body>
 </html>

--- a/cancel_subscription.php
+++ b/cancel_subscription.php
@@ -1,0 +1,24 @@
+<?php
+require 'config.php';
+require 'auth.php';
+require 'stripe_helper.php';
+require_once 'whm_helper.php';
+require_login();
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+if ($id > 0) {
+    $stmt = $pdo->prepare('SELECT stripe_subscription_id, domain FROM billing_subscriptions WHERE id = ? AND user_id = ?');
+    $stmt->execute([$id, current_user_id()]);
+    $sub = $stmt->fetch();
+    if ($sub) {
+        stripeRequest('POST', 'subscriptions/' . $sub['stripe_subscription_id'] . '/cancel');
+        $upd = $pdo->prepare('UPDATE billing_subscriptions SET status = ? WHERE id = ?');
+        $upd->execute(['canceled', $id]);
+        if (!empty($sub['domain'])) {
+            whmSuspendAccount($sub['domain']);
+        }
+    }
+}
+header('Location: account.php');
+exit;
+?>

--- a/dashboard.php
+++ b/dashboard.php
@@ -1,0 +1,1 @@
+<?php require 'account.php'; ?>

--- a/footer.php
+++ b/footer.php
@@ -1,0 +1,11 @@
+<footer class="bg-gray-800 text-white p-4 mt-8">
+    <div class="container mx-auto text-center">
+        <nav class="mb-2">
+            <a href="terms.php" class="mr-4 hover:underline">Terms</a>
+            <a href="privacy.php" class="mr-4 hover:underline">Privacy</a>
+            <a href="contact.php" class="mr-4 hover:underline">Contact</a>
+            <a href="login.php" class="hover:underline">Login</a>
+        </nav>
+        <p>&copy; <?php echo date('Y'); ?> Card2Website</p>
+    </div>
+</footer>

--- a/header.php
+++ b/header.php
@@ -1,0 +1,16 @@
+<?php
+?>
+<header class="bg-blue-700 text-white p-4">
+    <div class="container mx-auto flex justify-between items-center">
+        <div class="flex items-center">
+            <img src="cardbot.png" alt="Card2Website" class="h-8 mr-2">
+            <span class="font-bold">Card2Website</span>
+        </div>
+        <nav>
+            <a href="index.php" class="mr-4 hover:underline">Home</a>
+            <a href="dashboard.php" class="mr-4 hover:underline">Dashboard</a>
+            <a href="account.php" class="mr-4 hover:underline">Account</a>
+            <a href="contact.php" class="hover:underline">Contact</a>
+        </nav>
+    </div>
+</header>

--- a/login.php
+++ b/login.php
@@ -2,7 +2,7 @@
 require 'config.php';
 require 'auth.php';
 
-$next = $_GET['next'] ?? 'account.php';
+$next = $_GET['next'] ?? 'dashboard.php';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $email = trim($_POST['email'] ?? '');
     $password = $_POST['password'] ?? '';
@@ -27,8 +27,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <title>Login</title>
 <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-100 p-8">
-<div class="max-w-md mx-auto bg-white p-6 rounded shadow">
+<body class="bg-gray-100">
+<?php include 'header.php'; ?>
+<div class="max-w-md mx-auto bg-white p-6 rounded shadow mt-8">
 <h2 class="text-xl mb-4">Login</h2>
 <?php if (!empty($error)) echo '<p class="text-red-600">' . htmlspecialchars($error) . '</p>'; ?>
 <form method="post">
@@ -39,5 +40,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 </form>
 <p class="mt-2">No account? <a class="text-blue-600" href="register.php">Register</a></p>
 </div>
+<?php include 'footer.php'; ?>
 </body>
 </html>

--- a/payment.php
+++ b/payment.php
@@ -48,6 +48,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-gray-100">
+    <?php include 'header.php'; ?>
     <div class="container mx-auto p-8 max-w-md">
         <h1 class="text-2xl font-bold mb-4 text-center">
             <?= $loggedIn ? 'Choose Plan for ' . htmlspecialchars($domain) : 'Register ' . htmlspecialchars($domain) ?>
@@ -94,6 +95,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     });
     </script>
     <?php endif; ?>
+    <?php include 'footer.php'; ?>
 </body>
 </html>
 

--- a/portal.php
+++ b/portal.php
@@ -5,17 +5,20 @@ require 'stripe_helper.php';
 require_login();
 
 $userId = current_user_id();
-
-$stmt = $pdo->prepare('SELECT stripe_customer_id FROM billing_subscriptions WHERE user_id = ? ORDER BY id DESC LIMIT 1');
-$stmt->execute([$userId]);
-$sub = $stmt->fetch();
-if (!$sub) {
-    header('Location: account.php');
-    exit;
+$customerId = $_POST['customer_id'] ?? null;
+if (!$customerId) {
+    $stmt = $pdo->prepare('SELECT stripe_customer_id FROM billing_subscriptions WHERE user_id = ? ORDER BY id DESC LIMIT 1');
+    $stmt->execute([$userId]);
+    $sub = $stmt->fetch();
+    if (!$sub) {
+        header('Location: account.php');
+        exit;
+    }
+    $customerId = $sub['stripe_customer_id'];
 }
 
 $returnUrl = (isset($_SERVER['HTTPS']) ? 'https://' : 'http://') . $_SERVER['HTTP_HOST'] . '/account.php';
-$portal = createBillingPortalSession($sub['stripe_customer_id'], $returnUrl);
+$portal = createBillingPortalSession($customerId, $returnUrl);
 if ($portal && isset($portal['url'])) {
     header('Location: ' . $portal['url']);
     exit;

--- a/schema.sql
+++ b/schema.sql
@@ -84,6 +84,7 @@ CREATE TABLE IF NOT EXISTS billing_subscriptions (
     stripe_customer_id VARCHAR(255) NOT NULL,
     stripe_subscription_id VARCHAR(255) NOT NULL,
     plan_type VARCHAR(50),
+    domain VARCHAR(255),
     status VARCHAR(50),
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,

--- a/stripe_helper.php
+++ b/stripe_helper.php
@@ -43,15 +43,19 @@ function stripeRequest(string $method, string $endpoint, array $params = []) {
     return json_decode($response, true);
 }
 
-function createCheckoutSession(string $customerEmail, string $priceId, string $successUrl, string $cancelUrl, ?string $clientReferenceId = null) {
+function createCheckoutSession(string $customerEmail, string $priceId, string $successUrl, string $cancelUrl, ?string $clientReferenceId = null, ?string $customerId = null) {
     $separator = (strpos($successUrl, '?') === false) ? '?' : '&';
     $params = [
         'mode' => 'subscription',
-        'customer_email' => $customerEmail,
         'line_items' => [[ 'price' => $priceId, 'quantity' => 1 ]],
         'success_url' => $successUrl . $separator . 'session_id={CHECKOUT_SESSION_ID}',
         'cancel_url' => $cancelUrl
     ];
+    if ($customerId) {
+        $params['customer'] = $customerId;
+    } else {
+        $params['customer_email'] = $customerEmail;
+    }
     if ($clientReferenceId !== null) {
         $params['client_reference_id'] = $clientReferenceId;
     }

--- a/stripe_report.php
+++ b/stripe_report.php
@@ -1,0 +1,34 @@
+<?php
+require 'config.php';
+require 'stripe_helper.php';
+require_once 'whm_helper.php';
+
+header('Content-Type: application/json');
+
+$report = [];
+$stmt = $pdo->query('SELECT id, domain, stripe_subscription_id, stripe_customer_id, status FROM billing_subscriptions');
+$subs = $stmt->fetchAll();
+
+foreach ($subs as $sub) {
+    $stripeSub = stripeRequest('GET', 'subscriptions/' . $sub['stripe_subscription_id']);
+    if (!$stripeSub || !isset($stripeSub['status'])) {
+        continue;
+    }
+    $newStatus = $stripeSub['status'];
+    if ($newStatus !== $sub['status']) {
+        $upd = $pdo->prepare('UPDATE billing_subscriptions SET status = ?, updated_at = NOW() WHERE id = ?');
+        $upd->execute([$newStatus, $sub['id']]);
+        if ($newStatus !== 'active' && !empty($sub['domain'])) {
+            // Suspend hosting when subscription is not active
+            whmSuspendAccount($sub['domain']);
+        }
+    }
+    $report[] = [
+        'subscription_id' => $sub['stripe_subscription_id'],
+        'status' => $newStatus,
+        'domain' => $sub['domain']
+    ];
+}
+
+echo json_encode($report);
+?>

--- a/subscribe.php
+++ b/subscribe.php
@@ -24,7 +24,11 @@ $priceId = getenv($plan === 'yearly' ? 'STRIPE_PRICE_ID_YEARLY' : 'STRIPE_PRICE_
 $baseUrl = (isset($_SERVER['HTTPS']) ? 'https://' : 'http://') . $_SERVER['HTTP_HOST'];
 $successUrl = $baseUrl . '/subscribe_success.php?domain=' . urlencode($domain) . '&upload_id=' . $uploadId;
 $cancelUrl = $baseUrl . '/payment.php?domain=' . urlencode($domain) . '&upload_id=' . $uploadId;
-$session = createCheckoutSession($user['email'], $priceId, $successUrl, $cancelUrl, (string)$userId);
+$custStmt = $pdo->prepare('SELECT stripe_customer_id FROM billing_subscriptions WHERE user_id = ? ORDER BY id DESC LIMIT 1');
+$custStmt->execute([$userId]);
+$existing = $custStmt->fetch();
+$customerId = $existing['stripe_customer_id'] ?? null;
+$session = createCheckoutSession($user['email'], $priceId, $successUrl, $cancelUrl, (string)$userId, $customerId);
 if ($session && isset($session['url'])) {
     header('Location: ' . $session['url']);
     exit;

--- a/subscribe_success.php
+++ b/subscribe_success.php
@@ -20,8 +20,8 @@ if ($sessionId) {
             }
         }
         if ($userId) {
-            $stmt = $pdo->prepare('INSERT INTO billing_subscriptions (user_id, stripe_customer_id, stripe_subscription_id, plan_type, status) VALUES (?, ?, ?, ?, ?)');
-            $stmt->execute([$userId, $session['customer'], $session['subscription'], 'hosting', 'active']);
+            $stmt = $pdo->prepare('INSERT INTO billing_subscriptions (user_id, stripe_customer_id, stripe_subscription_id, plan_type, domain, status) VALUES (?, ?, ?, ?, ?, ?)');
+            $stmt->execute([$userId, $session['customer'], $session['subscription'], 'hosting', $domain, 'active']);
         }
     }
 }

--- a/whm_helper.php
+++ b/whm_helper.php
@@ -294,6 +294,11 @@ function createWhmAccount(string $username, string $domain, string $password): ?
     return whmApiRequest('createacct', $params);
 }
 
+function whmSuspendAccount(string $domain): ?array {
+    $username = substr(preg_replace('/[^a-z0-9]/i', '', explode('.', $domain)[0]), 0, 8);
+    return whmApiRequest('suspendacct', ['user' => $username]);
+}
+
 function uploadToCpanel(
     string $cpanelUser,
     string $cpanelPass,


### PR DESCRIPTION
## Summary
- Store domain per subscription to support multiple websites
- Reuse Stripe customers and list subscriptions in a themed account dashboard
- Add cron-friendly Stripe report that suspends hosting on inactive subs

## Testing
- `php -l header.php`
- `php -l footer.php`
- `php -l stripe_helper.php`
- `php -l subscribe.php`
- `php -l subscribe_success.php`
- `php -l account.php`
- `php -l portal.php`
- `php -l login.php`
- `php -l payment.php`
- `php -l stripe_report.php`
- `php -l whm_helper.php >/tmp/whm_helper_lint.log && tail -n 20 /tmp/whm_helper_lint.log`
- `php -l dashboard.php`
- `php -l cancel_subscription.php`

------
https://chatgpt.com/codex/tasks/task_e_68b37ac94acc8326bb42a56fba3495ae