### PR TITLE
Add password reset flow

### DIFF
--- a/forgot_password.php
+++ b/forgot_password.php
@@ -1,0 +1,48 @@
+<?php
+require 'config.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $email = trim($_POST['email'] ?? '');
+    if ($email) {
+        $stmt = $pdo->prepare('SELECT id FROM users WHERE email = ?');
+        $stmt->execute([$email]);
+        $user = $stmt->fetch();
+        if ($user) {
+            $token = bin2hex(random_bytes(32));
+            $expires = date('Y-m-d H:i:s', time() + 3600);
+            $pdo->prepare('INSERT INTO password_resets (user_id, token, expires_at) VALUES (?, ?, ?)')
+                ->execute([$user['id'], $token, $expires]);
+            $baseUrl = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? 'https' : 'http')
+                . '://' . $_SERVER['HTTP_HOST'];
+            $resetLink = $baseUrl . '/reset_password.php?token=' . $token;
+            @mail($email, 'Password Reset', 'To reset your password, click the following link: ' . $resetLink);
+        }
+        $sent = true;
+    } else {
+        $error = 'Email required';
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Forgot Password</title>
+<script src='https://cdn.tailwindcss.com'></script>
+</head>
+<body class='bg-gray-100'>
+<?php include 'header.php'; ?>
+<div class='max-w-md mx-auto bg-white p-6 rounded shadow mt-8'>
+<h2 class='text-xl mb-4'>Reset Password</h2>
+<?php if (!empty($sent)) { echo '<p>If an account with that email exists, a reset link has been sent.</p>'; } else { ?>
+<?php if (!empty($error)) echo '<p class="text-red-600">' . htmlspecialchars($error) . '</p>'; ?>
+<form method='post'>
+<input class='border p-2 w-full mb-4' type='email' name='email' placeholder='Email' required />
+<button class='bg-blue-600 text-white px-4 py-2 rounded' type='submit'>Send Reset Link</button>
+</form>
+<?php } ?>
+</div>
+<?php include 'footer.php'; ?>
+</body>
+</html>
+

--- a/login.php
+++ b/login.php
@@ -38,6 +38,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <input type="hidden" name="next" value="<?= htmlspecialchars($next) ?>" />
 <button class="bg-blue-600 text-white px-4 py-2 rounded" type="submit">Login</button>
 </form>
+<p class="mt-2"><a class="text-blue-600" href="forgot_password.php">Forgot your password?</a></p>
 <p class="mt-2">No account? <a class="text-blue-600" href="register.php">Register</a></p>
 </div>
 <?php include 'footer.php'; ?>

--- a/reset_password.php
+++ b/reset_password.php
@@ -1,0 +1,53 @@
+<?php
+require 'config.php';
+
+$token = $_GET['token'] ?? $_POST['token'] ?? '';
+if ($token) {
+    $stmt = $pdo->prepare('SELECT user_id, expires_at FROM password_resets WHERE token = ?');
+    $stmt->execute([$token]);
+    $reset = $stmt->fetch();
+    if (!$reset || strtotime($reset['expires_at']) < time()) {
+        $error = 'Invalid or expired token';
+    }
+} else {
+    $error = 'Invalid token';
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && empty($error)) {
+    $password = $_POST['password'] ?? '';
+    if ($password) {
+        $hash = password_hash($password, PASSWORD_DEFAULT);
+        $pdo->prepare('UPDATE users SET password_hash = ? WHERE id = ?')
+            ->execute([$hash, $reset['user_id']]);
+        $pdo->prepare('DELETE FROM password_resets WHERE token = ?')
+            ->execute([$token]);
+        $success = true;
+    } else {
+        $error = 'Password required';
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='UTF-8'>
+<title>Set New Password</title>
+<script src='https://cdn.tailwindcss.com'></script>
+</head>
+<body class='bg-gray-100'>
+<?php include 'header.php'; ?>
+<div class='max-w-md mx-auto bg-white p-6 rounded shadow mt-8'>
+<h2 class='text-xl mb-4'>Set New Password</h2>
+<?php if (!empty($success)) { echo '<p>Password updated. <a class="text-blue-600" href="login.php">Login</a></p>'; } elseif (!empty($error)) { echo '<p class="text-red-600">' . htmlspecialchars($error) . '</p>'; } ?>
+<?php if (empty($success) && empty($error)) { ?>
+<form method='post'>
+<input class='border p-2 w-full mb-4' type='password' name='password' placeholder='New Password' required />
+<input type='hidden' name='token' value='<?= htmlspecialchars($token) ?>' />
+<button class='bg-blue-600 text-white px-4 py-2 rounded' type='submit'>Reset Password</button>
+</form>
+<?php } ?>
+</div>
+<?php include 'footer.php'; ?>
+</body>
+</html>
+

--- a/schema.sql
+++ b/schema.sql
@@ -102,3 +102,12 @@ CREATE TABLE IF NOT EXISTS website_images (
     FOREIGN KEY (user_id) REFERENCES users(id)
 );
 
+CREATE TABLE IF NOT EXISTS password_resets (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    token VARCHAR(64) NOT NULL UNIQUE,
+    expires_at DATETIME NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+


### PR DESCRIPTION
## Summary
- add `password_resets` table for storing one-time reset tokens
- create `forgot_password.php` to generate and email reset links
- create `reset_password.php` to update passwords using the token
- link login page to reset workflow

## Testing
- `php -l forgot_password.php`
- `php -l reset_password.php`
- `php -l login.php`


------
https://chatgpt.com/codex/tasks/task_e_68b37bf780fc83268c4404f16584f81b