### PR TITLE
Fix inline display of generated sites

### DIFF
--- a/download.php
+++ b/download.php
@@ -1,11 +1,21 @@
 <?php
 $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 $file = __DIR__ . '/generated_sites/' . $id . '.html';
+
 if (!file_exists($file)) {
     http_response_code(404);
     echo 'File not found';
     exit;
 }
+
+// If display flag is set, show the HTML in the browser instead of forcing download
+if (isset($_GET['display']) && (int)$_GET['display'] === 1) {
+    header('Content-Type: text/html');
+    readfile($file);
+    exit;
+}
+
+// Default behaviour: force download of the generated site
 header('Content-Type: application/octet-stream');
 header('Content-Disposition: attachment; filename="site_' . $id . '.html"');
 readfile($file);


### PR DESCRIPTION
## Summary
- Add support in `download.php` to display generated HTML inline when `display=1` is provided
- Default behavior still forces download when `display` flag is absent

## Testing
- `php -l download.php`


------
https://chatgpt.com/codex/tasks/task_e_68b52da1cde88326a0002200fabd82af