### PR TITLE
Add output language selector on preview page

### DIFF
--- a/generate.php
+++ b/generate.php
@@ -12,6 +12,10 @@ require_once 'gemini_helper.php';
 require_once 'auth.php';
 require_once 'i18n.php';
 
+if (isset($_POST['output_lang'])) {
+    setOutputLanguage($_POST['output_lang']);
+}
+
 $baseUrl = (isset($_SERVER['HTTPS']) ? 'https://' : 'http://') . $_SERVER['HTTP_HOST'];
 
 define('BASEURL', $baseUrl);

--- a/preview.php
+++ b/preview.php
@@ -1,5 +1,9 @@
 <?php
 require 'config.php';
+require_once 'i18n.php';
+
+$supportedLanguages = getSupportedLanguages();
+$currentOutputLang = getOutputLanguage();
 
 $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 $stmt = $pdo->prepare('SELECT filename FROM uploads WHERE id = ?');
@@ -455,6 +459,13 @@ foreach ($previewFiles as $file) {
             
             <label class="block mt-4 mb-2 font-semibold">Describe your business</label>
             <textarea name="additional_details" rows="4" class="w-full border p-2 text-sm"></textarea>
+
+            <label class="block mt-4 mb-2 font-semibold">Website output language</label>
+            <select name="output_lang" class="border rounded p-2 text-sm">
+                <?php foreach ($supportedLanguages as $code => $name): ?>
+                <option value="<?php echo htmlspecialchars($code); ?>" <?php echo $code === $currentOutputLang ? 'selected' : ''; ?>><?php echo htmlspecialchars($name); ?></option>
+                <?php endforeach; ?>
+            </select>
 
             <?php if (!empty($layoutPreviews)): ?>
             <label class="block mt-4 mb-2 font-semibold">Choose a site layout</label>


### PR DESCRIPTION
## Summary
- Ask user for website output language on preview page, defaulting to browser language or English
- Forward selected output language into site generation

## Testing
- `php -l preview.php`
- `php -l generate.php`

------
https://chatgpt.com/codex/tasks/task_e_68b53372c06c8326b73593e21e89a9cf