### PR TITLE
Fix image_url payload structure for ChatCompletions

### DIFF
--- a/openai_helper.php
+++ b/openai_helper.php
@@ -731,7 +731,8 @@ USR;
             'role' => 'user',
             'content' => [
                 ['type' => 'text', 'text' => $userContent],
-                ['type' => 'image_url', 'image_url' => $layoutImageUrl]
+                // The API expects image_url to be an object with a url key
+                ['type' => 'image_url', 'image_url' => ['url' => $layoutImageUrl]]
             ]
         ];
     } else {


### PR DESCRIPTION
## Summary
- ensure layout image is passed as object with url key to Chat Completions API

## Testing
- `php -l openai_helper.php`


------
https://chatgpt.com/codex/tasks/task_e_68b53e40a99c8326854e83a3b84edf8e