### PR TITLE
Improve generation UX with spinner and inline preview

### DIFF
--- a/preview.php
+++ b/preview.php
@@ -437,6 +437,13 @@ foreach ($previewFiles as $file) {
 </head>
 <body class="bg-gray-100">
     <?php include 'header.php'; ?>
+    <div id="loadingOverlay" class="fixed inset-0 bg-black bg-opacity-75 flex items-center justify-center text-white text-xl hidden">
+        <svg class="animate-spin h-12 w-12 mr-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path>
+        </svg>
+        Generating your site...
+    </div>
     <div class="container mx-auto p-8">
         <h1 class="text-2xl font-bold mb-4 text-center">Preview</h1>
         <div class="text-center mb-6">
@@ -673,22 +680,14 @@ function scrollFiles(direction) {
     }
 }
 
-// SIMPLE FORM SUBMISSION - just update file input before submit
-/*
-document.getElementById('dataForm').addEventListener('submit', function(e) {
-    console.log('Form submitting...'); // Debug log
-    
-    // Update the file input with selected files
+// Update file input and show spinner before submitting the form
+const dataForm = document.getElementById('dataForm');
+dataForm.addEventListener('submit', function(e) {
     const dt = new DataTransfer();
     selectedFiles.forEach(file => dt.items.add(file));
     fileInput.files = dt.files;
-    
-    console.log('Files attached:', selectedFiles.length);
-    
-    // Let the form submit normally
-    return true;
+    document.getElementById('loadingOverlay').classList.remove('hidden');
 });
-*/
 </script>
 </body>
 </html>

--- a/view_site.php
+++ b/view_site.php
@@ -38,7 +38,7 @@ $html = stripslashes($html);
         <h1 class="text-2xl font-bold mb-4 text-center">Your Generated Site</h1>
         <div class="bg-white p-4 rounded shadow mb-4">
             <button id="toggleEditor" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" style="float: right; margin-bottom: 8px;">Edit Web Page</button>
-            <iframe id="siteFrame" src="download.php?id=<?php echo $id; ?>&display=1" class="w-full h-96"></iframe>
+            <iframe id="siteFrame" src="generated_sites/<?php echo $id; ?>.html?v=<?php echo time(); ?>" class="w-full h-96"></iframe>
         </div>
         <div class="text-center mt-4">
             <a href="download.php?id=<?= $id ?>" class="bg-green-600 text-white px-4 py-2 rounded">Download HTML</a>
@@ -50,6 +50,7 @@ $html = stripslashes($html);
         document.addEventListener('DOMContentLoaded', function () {
             const iframe = document.getElementById('siteFrame');
             const btn = document.getElementById('toggleEditor');
+            const viewSrc = 'generated_sites/<?php echo $id; ?>.html';
             let editing = false;
 
             btn.addEventListener('click', function () {
@@ -57,7 +58,7 @@ $html = stripslashes($html);
                     iframe.src = 'edit_site.php?id=<?php echo $id; ?>';
                     btn.textContent = 'View Web Page';
                 } else {
-                    iframe.src = 'download.php?id=<?php echo $id; ?>&display=1';
+                    iframe.src = viewSrc + '?v=' + Date.now();
                     btn.textContent = 'Edit Web Page';
                 }
                 editing = !editing;


### PR DESCRIPTION
## Summary
- Show full-screen spinner while generating a site
- Load generated HTML directly into preview iframe

## Testing
- `php -l view_site.php`
- `php -l preview.php`


------
https://chatgpt.com/codex/tasks/task_e_68b547f72f008326ae1d15171b8bbbdd