### PR TITLE
Fix duplicated header in edit view

### DIFF
--- a/edit_site.php
+++ b/edit_site.php
@@ -76,7 +76,6 @@ $iframeSrc = "/generated_sites/{$id}.html?v=" . time();
 
   <!-- Hidden inputs for image uploads -->
   <input type="file" id="imagePicker" accept="image/*" style="display:none" />
-  <?php include 'footer.php'; ?>
   <script>
     (function(){
       const iframe = document.getElementById('siteFrame');
@@ -117,10 +116,8 @@ $iframeSrc = "/generated_sites/{$id}.html?v=" . time();
           doc.body.setAttribute('contenteditable', 'true');
           doc.body.style.caretColor = '#000';
 
-          // Exclude header and footer from editing
-          doc.querySelectorAll('header, footer').forEach(el => {
-            el.setAttribute('contenteditable', 'false');
-          });
+          // Strip header and footer from the editable content
+          doc.querySelectorAll('header, footer').forEach(el => el.remove());
 
           // Prevent navigation while editing (clicking links)
           doc.addEventListener('click', (e) => {
@@ -244,9 +241,7 @@ $iframeSrc = "/generated_sites/{$id}.html?v=" . time();
           // Re-init editable bits after replacing doc
           doc = iframe.contentDocument || iframe.contentWindow.document;
           doc.body.setAttribute('contenteditable', 'true');
-          doc.querySelectorAll('header, footer').forEach(el => {
-            el.setAttribute('contenteditable', 'false');
-          });
+          doc.querySelectorAll('header, footer').forEach(el => el.remove());
           sourceArea.style.display = 'none';
           setStatus('Source applied.');
         }
@@ -334,5 +329,6 @@ $iframeSrc = "/generated_sites/{$id}.html?v=" . time();
       });
     })();
   </script>
+  <?php include 'footer.php'; ?>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- include `header.php` and `footer.php` in `edit_site.php`
- strip header and footer elements from the editable iframe content

## Testing
- `php -l edit_site.php`


------
https://chatgpt.com/codex/tasks/task_e_68b7dc3179148326b2e69e5e84617c12