### PR TITLE
Preserve full HTML when saving edits

### DIFF
--- a/edit_site.php
+++ b/edit_site.php
@@ -415,8 +415,9 @@ $iframeSrc = "/generated_sites/{$id}.html?v=" . time();
         const preserved = doc.querySelectorAll('[data-c2w-preserve]');
         preserved.forEach(el => el.style.display = '');
 
-        // Get only the body content for saving (exclude the full document structure)
+        // Capture both the body content and the full document HTML
         const bodyContent = doc.body.innerHTML;
+        const fullHtml = doc.documentElement.outerHTML;
 
         // Re-hide preserved elements for continued editing
         preserved.forEach(el => el.style.display = 'none');
@@ -430,7 +431,7 @@ $iframeSrc = "/generated_sites/{$id}.html?v=" . time();
               id: <?php echo $id; ?>,
               nonce: '<?php echo $nonce; ?>',
               html: bodyContent,
-              full_html: doc.documentElement.outerHTML // Send both for flexibility
+              full_html: fullHtml // Send both for flexibility
             })
           });
           const json = await parseJsonSafely(resp);

--- a/save_html.php
+++ b/save_html.php
@@ -26,17 +26,20 @@ if (empty($input['nonce']) || empty($_SESSION['editor_nonce']) || !hash_equals($
 }
 
 $id   = isset($input['id']) ? (int) $input['id'] : 0; // upload_id
-$html = $input['html'] ?? '';
-if ($id <= 0 || !$html) {
+// Prefer full_html if provided; fall back to body-only html for backward compatibility
+$html = $input['full_html'] ?? $input['html'] ?? '';
+if ($id <= 0 || $html === '') {
     fail('Missing id or html');
 }
 
-// Inject script that visualizes background image focal points
+// Inject script that visualizes background image focal points if not already present
 $focalScriptTag = '<script src="/focal_point.js"></script>';
-if (stripos($html, '</body>') !== false) {
-    $html = preg_replace('/<\/body>/i', $focalScriptTag . '</body>', $html, 1);
-} else {
-    $html .= $focalScriptTag;
+if (stripos($html, 'focal_point.js') === false) {
+    if (stripos($html, '</body>') !== false) {
+        $html = preg_replace('/<\/body>/i', $focalScriptTag . '</body>', $html, 1);
+    } else {
+        $html .= $focalScriptTag;
+    }
 }
 
 // Basic sanitation idea: allow full doc but you may want to sanitize/strip scripts if needed.


### PR DESCRIPTION
## Summary
- send full document HTML from editor before hiding elements
- accept full HTML in save handler and avoid stripping <html> tags

## Testing
- `php -l edit_site.php`
- `php -l save_html.php`


------
https://chatgpt.com/codex/tasks/task_e_68be607fc9f88326a82c54ed08cc9ec7