### PR TITLE
Implement dynamic localization using OpenAI translations

### DIFF
--- a/header.php
+++ b/header.php
@@ -7,13 +7,13 @@ $outputLang = getOutputLanguage();
 <header class="bg-white border-b">
     <div class="container mx-auto flex justify-between items-center p-4">
         <div class="flex items-center">
-            <img src="cardbot.png" alt="Business Card to Website" class="h-8 mr-2">
-            <span class="font-bold text-xl text-gray-900">Business Card to Website</span>
+            <img src="cardbot.png" alt="<?=__('business_card_to_website')?>" class="h-8 mr-2">
+            <span class="font-bold text-xl text-gray-900"><?=__('business_card_to_website')?></span>
         </div>
         <nav class="flex items-center space-x-6 text-gray-700">
-            <a href="#" class="hover:text-blue-600">Gallery</a>
-            <a href="#" class="hover:text-blue-600">Pricing</a>
-            <a href="contact.php" class="hover:text-blue-600">Contact</a>
+            <a href="#" class="hover:text-blue-600"><?=__('gallery')?></a>
+            <a href="#" class="hover:text-blue-600"><?=__('pricing')?></a>
+            <a href="contact.php" class="hover:text-blue-600"><?=__('contact')?></a>
             <form action="set_language.php" method="post" class="ml-4">
                 <input type="hidden" name="output_lang" value="<?=$outputLang?>">
                 <select name="app_lang" onchange="this.form.submit()" class="border rounded px-2 py-1 text-sm">

--- a/lang/en.php
+++ b/lang/en.php
@@ -8,6 +8,8 @@ return [
     'tagline' => 'Turn your business card into a professional website',
     'upload_card' => 'Upload your business card',
     'generate_website' => 'Generate Website',
+    'gallery' => 'Gallery',
+    'pricing' => 'Pricing',
     'switch_language' => 'Switch to {language}',
     'swap_languages' => 'Swap'
 ];

--- a/schema.sql
+++ b/schema.sql
@@ -111,3 +111,11 @@ CREATE TABLE IF NOT EXISTS password_resets (
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 );
 
+CREATE TABLE IF NOT EXISTS translations (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    english_phrase VARCHAR(255) NOT NULL,
+    language VARCHAR(5) NOT NULL,
+    translated_phrase TEXT NOT NULL,
+    UNIQUE KEY unique_translation (english_phrase, language)
+);
+


### PR DESCRIPTION
## Summary
- Add translations table for storing localized phrases
- Implement translation helper that defaults to English, uses OpenAI for missing phrases, and caches results
- Localize site header and navigation using new translation system

## Testing
- `php -l i18n.php`
- `php -l header.php`
- `php -l lang/en.php`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68c12825bfe48326b603bf485f6d76d0